### PR TITLE
Name anonymous parameters with default values

### DIFF
--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -1,7 +1,17 @@
 using MacroTools
 using MacroTools: @q, combinedef
 
-named(arg) = isexpr(arg, :(::)) && length(arg.args) == 1 ? :($(gensym())::$(arg.args[1])) : arg
+function named(arg)
+  if isexpr(arg, :(::)) && length(arg.args) == 1
+    :($(gensym())::$(arg.args[1]))
+  elseif isexpr(arg, :kw)
+    @assert length(arg.args) == 2
+    decl, default = arg.args
+    Expr(:kw, named(decl), default)
+  else
+    arg
+  end
+end
 
 typeless(x) = MacroTools.postwalk(x -> isexpr(x, :(::), :kw) ? x.args[1] : x, x)
 isvararg(x) = isexpr(x, :(::)) && namify(x.args[2]) == :Vararg

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using ZygoteRules, Test
+using ZygoteRules: typeless, named
 
 foo(x) = 2x
 @adjoint foo(x) = 3x, ȳ -> (3,)
@@ -6,3 +7,38 @@ foo(x) = 2x
 # using Zygote
 
 # @test gradient(foo, x) == (3,)
+
+"""
+Extract the first parameter declaration from a function definition
+
+This macro is necessary because the same syntax is parsed differently if it is part of a
+parameter list, see the first test.
+"""
+macro param(def)
+  @assert def.head == :function
+  head = def.args[1]
+  call = head.head == :where ? head.args[1] : head
+  QuoteNode(call.args[2])
+end
+
+@testset "Test utilities" begin
+  @test @param(function f(a::Int = 5) end) != :(a::Int = 5)
+
+  @test @param(function f(x) end) == :(x)
+  @test @param(function f(a::Int = 5) end) == Expr(:kw, :(a::Int), 5)
+end
+
+@testset "Macro utilities" begin
+  @testset "extracting parameter names" begin
+    @test typeless(@param function f(x) end) == :x
+    @test typeless(@param function f(b::Float64 = π) end) == :b
+  end
+
+  @testset "naming anonymous parameters" begin
+    @test typeless(named(@param function f(w) end)) == :w
+    @test typeless(named(@param function f(σ::Float32 = 1.0) end)) == :σ
+
+    @test typeless(named(@param function f(::Int) end)) isa Symbol
+    @test typeless(named(@param function f(::Type{Val{x}}) where {x} end)) isa Symbol
+  end
+end


### PR DESCRIPTION
Consider the following code.

```julia
f(::Type{Val{x}} = Val{false}) where {x} = 1.0

@adjoint function f(::Type{Val{x}} = Val{false}) where {x}
  # ...
end
```

Similar code occurs in RecursiveArrayTools. Without this fix, `Type{Val{x}}` will be considered the name of the parameter.