### PR TITLE
Minimal support for foward mode

### DIFF
--- a/src/ZygoteRules.jl
+++ b/src/ZygoteRules.jl
@@ -12,4 +12,8 @@ literal_getproperty(x, ::Val{f}) where f = getproperty(x, f)
 
 include("adjoint.jl")
 
+# Forward mode:
+function pushforward end
+function _pushforward end
+
 end

--- a/src/ZygoteRules.jl
+++ b/src/ZygoteRules.jl
@@ -16,4 +16,10 @@ include("adjoint.jl")
 function pushforward end
 function _pushforward end
 
+# ForwardDiff interface:
+function seed end
+function extract end
+function forward_jacobian end
+function forwarddiff end
+
 end


### PR DESCRIPTION
This just adds empty stubs for pushforward functions. This should be enough to let you call them within a backward-mode rule `@adjoint map(f, xs) = ...`.

It is not enough to let you define new forward rules. I'm not sure whether `@tangent` is stable enough to also move over... that's a bigger job which could be done later. 