### PR TITLE
Add `clamptype` mechanism, to project into cotangent space

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "700de1a5-db45-46bc-99cf-38207098b444"
 version = "0.2.1"
 
 [deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ZygoteRules"
 uuid = "700de1a5-db45-46bc-99cf-38207098b444"
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,6 @@ uuid = "700de1a5-db45-46bc-99cf-38207098b444"
 version = "0.2.2"
 
 [deps]
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 
 [compat]


### PR DESCRIPTION
This adds a mechanism to constrain tangents based on the type of the input. The initial goal is ensuring that real numbers do not accidentally acquire complex gradients, and that some LinearAlgebra structured arrays are preserved.

Edit -- the bulk of the implementation is now at https://github.com/FluxML/Zygote.jl/pull/965, this is just a stub. (Which ought to be non-breaking.) I've moved discussion there. 