### PR TITLE
getproperty type-stability work-around

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ZygoteRules"
 uuid = "700de1a5-db45-46bc-99cf-38207098b444"
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/src/ZygoteRules.jl
+++ b/src/ZygoteRules.jl
@@ -19,5 +19,6 @@ In Zygote, differentiation of property access is defined by defining adjoint of
 literal_getfield(x, ::Val{f}) where f = getfield(x, f)
 
 include("adjoint.jl")
+include("getproperty_performance_workaround.jl")
 
 end

--- a/src/getproperty_performance_workaround.jl
+++ b/src/getproperty_performance_workaround.jl
@@ -6,11 +6,13 @@ known performance issue in Zygote.
 
 To use this for your type `YourType`, copy + paste the following
 ```julia
-import ZygoteRules: _pullback, AContext, literal_getproperty
-function _pullback(
+using ZygoteRules
+using ZygoteRules: AContext, literal_getproperty, pullback_for_default_literal_getproperty
+
+function ZygoteRules._pullback(
   cx::AContext, ::typeof(literal_getproperty), x::YourType, ::Val{f}
 ) where {f}
-  return pullback_for_default_method_of_literal_getproperty(cx, x, Val{f}())
+    return pullback_for_default_literal_getproperty(cx, x, Val{f}())
 end
 ```
 and replace `YourType` with the name of your type.

--- a/src/getproperty_performance_workaround.jl
+++ b/src/getproperty_performance_workaround.jl
@@ -1,0 +1,33 @@
+"""
+  pullback_for_default_literal_getproperty(cx::AContext, x, ::Val{f}) where {f}
+
+Performant pullback implementation for the default method of `getproperty`. Works around a
+known performance issue in Zygote.
+
+To use this for your type `YourType`, copy + paste the following
+```julia
+import ZygoteRules: _pullback, AContext, literal_getproperty
+function _pullback(
+  cx::AContext, ::typeof(literal_getproperty), x::YourType, ::Val{f}
+) where {f}
+  return pullback_for_default_method_of_literal_getproperty(cx, x, Val{f}())
+end
+```
+and replace `YourType` with the name of your type.
+
+You _should_ make use of this method if you have not implemented
+`getproperty(::YourType, ::Symbol)`.
+
+Conversely, you should _not_ make use of this functionality if you have a custom
+implementation of `getproperty`. Instead, you should directly implement a pullback for
+`literal_getproperty` that is correct for your method.
+
+You can locate this method anywhere in your code.
+
+If you come across a type implemented in the Julia Base or the standard libraries for which
+this workaround is appropriate, but for which it has not yet been implemented, please
+consider opening an issue or (better yet) a PR to Zygote to add this method for that type.
+"""
+function pullback_for_default_literal_getproperty(cx::AContext, x, ::Val{f}) where {f}
+  return _pullback(cx, literal_getfield, x, Val{f}())
+end


### PR DESCRIPTION
Provides a hook and instructions to make it easy for type-authors to work around the getproperty performance issue.

Counterpart PR with docs and tests made to Zygote https://github.com/FluxML/Zygote.jl/pull/1091