### PR TITLE
Collapse tuples of `nothing`

### DIFF
--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -21,6 +21,7 @@ for n = 0:3
   gradtuple = Symbol(:gradtuple, n)
   @eval begin
     $gradtuple(x::Tuple) = ($(ntuple(_->:nothing,n)...), x...)
+    $gradtuple(::Tuple{Vararg{Nothing}}) = nothing
     $gradtuple(x::Nothing) = nothing
     $gradtuple(x) = error("Gradient $x should be a tuple")
   end


### PR DESCRIPTION
Zygote uses the convention that tuples of `nothing` are collapsed to a single `nothing`. However, currently this convention is not applied to `@adjoint`s. The PR fixes this, as suggested in https://github.com/FluxML/Zygote.jl/issues/1464#issuecomment-1760809337.