### PR TITLE
Add downstream tests

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -1,0 +1,58 @@
+  
+name: IntegrationTest
+on:
+  push:
+    branches: [master]
+    tags: [v*]
+  pull_request:
+
+jobs:
+  test:
+    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}
+    runs-on: ${{ matrix.os }}
+    env:
+      GROUP: ${{ matrix.package.group }}
+    strategy:
+      fail-fast: false
+      matrix:
+        julia-version: [1]
+        os: [ubuntu-latest]
+        package:
+          - {user: FluxML, repo: Flux.jl, group: All}
+          - {user: FluxML, repo: NNlib.jl, group: All}
+          - {user: FluxML, repo: Zygote.jl, group: All}
+          - {user: TuringLang, repo: DynamicPPL.jl, group: All}
+          - {user: TuringLang, repo: DistributionsAD.jl, group: Zygote}
+          - {user: SciML, repo: DiffEqFlux.jl, group: Layers}
+          - {user: SciML, repo: DiffEqFlux.jl, group: BasicNeuralDE}
+          - {user: SciML, repo: NeuralPDE.jl, group: NNPDE}
+          - {user: JuliaMolSim, repo: Molly.jl, group: Zygote}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+          arch: x64
+      - uses: julia-actions/julia-buildpkg@latest
+      - name: Clone Downstream
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
+          path: downstream
+      - name: Load this and run the downstream tests
+        shell: julia --color=yes --project=downstream {0}
+        run: |
+          using Pkg
+          try
+            # force it to use this PR's version of the package
+            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
+            Pkg.update()
+            Pkg.test()  # resolver may fail with test time deps
+          catch err
+            err isa Pkg.Resolve.ResolverError || rethrow()
+            # If we can't resolve that means this is incompatible by SemVer and this is fine
+            # It means we marked this as a breaking change, so we don't need to worry about
+            # Mistakenly introducing a breaking change, as we have intentionally made one
+            @info "Not compatible with this release. No problem." exception=err
+            exit(0)  # Exit immediately, as a success
+          end

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -1,5 +1,5 @@
-  
 name: IntegrationTest
+
 on:
   push:
     branches: [master]


### PR DESCRIPTION
This PR copies the downstream tests of Zygote and adds Zygote itself to them, to make it easier to test changes such as #26 and avoid accidentally breaking Zygote and/or its ecosystem.